### PR TITLE
Add Railjet::Listener

### DIFF
--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -28,6 +28,12 @@ module Railjet
       bus.subscribe(subscriber, on: event, prefix: true, async: true)
     end
 
+    def subscribe_listener(listener)
+      listener.subscriptions.each do |event|
+        subscribe(event, listener)
+      end
+    end
+
     private
 
     attr_reader :bus

--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -32,4 +32,50 @@ module Railjet
 
     attr_reader :bus
   end
+
+  class Listener
+    include Railjet::Util::UseCaseHelper
+
+    class << self
+      def subscriptions
+        @subscriptions ||= []
+      end
+
+      def listen_to(event, &block)
+        subscriptions << event
+        define_listeners(event, &block)
+      end
+
+      private
+
+      def define_listeners(event, &block)
+        name = listener_name(event)
+        define_listener(name, &block)
+        define_listener_caller(name)
+      end
+
+      def define_listener(name, &block)
+        define_method name do |**kwargs|
+          around_listener(kwargs) { |args| instance_exec(args, &block) }
+        end
+      end
+
+      def define_listener_caller(name)
+        define_singleton_method name do |**kwargs|
+          new.public_send(name, **kwargs)
+        end
+      end
+
+      def listener_name(event)
+        "on_#{event}"
+      end
+    end
+
+    # This around block does nothing
+    # but it's there as point of extensions so it could be easily overridden in
+    # sub-class if some additional setup is needed
+    def around_listener(**kwargs)
+      yield(**kwargs)
+    end
+  end
 end

--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -55,18 +55,18 @@ module Railjet
       private
 
       def define_listeners(event, &block)
-        name = listener_name(event)
-        define_listener(name, &block)
-        define_listener_caller(name)
+        define_listener(event, &block)
+        define_listener_caller(event)
       end
 
-      def define_listener(name, &block)
-        define_method name do |**kwargs|
-          around_listener(kwargs) { |args| instance_exec(args, &block) }
+      def define_listener(event, &block)
+        define_method listener_name(event) do |**kwargs|
+          around_listener(event, kwargs) { |args| instance_exec(args, &block) }
         end
       end
 
-      def define_listener_caller(name)
+      def define_listener_caller(event)
+        name = listener_name(event)
         define_singleton_method name do |**kwargs|
           new.public_send(name, **kwargs)
         end
@@ -80,7 +80,7 @@ module Railjet
     # This around block does nothing
     # but it's there as point of extensions so it could be easily overridden in
     # sub-class if some additional setup is needed
-    def around_listener(**kwargs)
+    def around_listener(event, **kwargs)
       yield(**kwargs)
     end
   end

--- a/spec/railjet/listener_spec.rb
+++ b/spec/railjet/listener_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+require "railjet/bus"
+
+describe Railjet::Listener do
+  class DummyListener < Railjet::Listener
+    listen_to :dummy_event do
+      "Dummy event run"
+    end
+
+    listen_to :dummy_event_with_arg do |x: 1|
+      "Dummy event run with arg: #{x}"
+    end
+  end
+
+  subject(:listener) { DummyListener }
+
+  it "registers subscriptions" do
+    expect(listener.subscriptions).to eq %i[dummy_event dummy_event_with_arg]
+  end
+
+  describe "calling through class method" do
+    it "calls listener" do
+      expect(listener.on_dummy_event).to eq "Dummy event run"
+    end
+
+    it "calls listener with default args" do
+      expect(listener.on_dummy_event_with_arg).to eq "Dummy event run with arg: 1"
+    end
+
+    it "calls listener overriding default args" do
+      expect(listener.on_dummy_event_with_arg(x: 2)).to eq "Dummy event run with arg: 2"
+    end
+  end
+
+  describe "#around_listener callback" do
+    class DummyListenerWithCallback < Railjet::Listener
+      attr_accessor :tenant_id
+
+      def around_listener(**kwargs)
+        self.tenant_id = kwargs.fetch(:tenant_id)
+        yield(**kwargs.except(:tenant_id))
+      ensure
+        self.tenant_id = nil
+      end
+
+      listen_to :dummy_event do
+        "Dummy event run with tenant set: #{tenant_id}"
+      end
+
+      listen_to :dummy_event_with_arg do |x: 1|
+        "Dummy event run with arg: #{x} and tenant set: #{tenant_id}"
+      end
+    end
+
+    subject(:listener) { DummyListenerWithCallback }
+
+    it "calls listener" do
+      expect(listener.on_dummy_event(tenant_id: 111)).to eq "Dummy event run with tenant set: 111"
+    end
+
+    it "calls listener with default args" do
+      expect(listener.on_dummy_event_with_arg(tenant_id: 222)).to eq "Dummy event run with arg: 1 and tenant set: 222"
+    end
+
+    it "calls listener overriding default args" do
+      expect(listener.on_dummy_event_with_arg(tenant_id: 333, x: 2)).to eq "Dummy event run with arg: 2 and tenant set: 333"
+    end
+  end
+end


### PR DESCRIPTION
This is more or less copy&paste extraction of our Worksheet::Listener base class.

Of course I skipped whole CareProvider setup, but added a nice point of extension (`#around_listener`) so we could add it in clean manner.

It also adds `#subscribe_listener` to `Railjet::EventBus` so that, whole Listener could be subscribed at once.