### PR TITLE
Update wisper-sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
     railjet-bus (2.0.0)
       railjet (~> 3.0.0)
       wisper (~> 2.0)
-      wisper-sidekiq (~> 0.0.1)
+      wisper-sidekiq (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -89,8 +89,8 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     wisper (2.0.0)
     wisper-rspec (0.0.3)
-    wisper-sidekiq (0.0.1)
-      sidekiq
+    wisper-sidekiq (1.2.0)
+      sidekiq (>= 4.1)
       wisper
 
 PLATFORMS

--- a/railjet-bus.gemspec
+++ b/railjet-bus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency             "railjet",              "~> 3.0.0"
   spec.add_dependency             "wisper",               "~> 2.0"
-  spec.add_dependency             "wisper-sidekiq",       "~> 0.0.1"
+  spec.add_dependency             "wisper-sidekiq",       "~> 1.0"
 
   spec.add_development_dependency "bundler",              "~> 1.11"
   spec.add_development_dependency "rake",                 "~> 11.0"


### PR DESCRIPTION
- Lock on major version
- Adds support for Sidekiq 5
- Adds support for `sidekiq_options`

