### PR TITLE
Define #sidekiq_options class method on Railjet::Listener

### DIFF
--- a/lib/railjet-bus.rb
+++ b/lib/railjet-bus.rb
@@ -1,7 +1,8 @@
+require "wisper"
+require "wisper/sidekiq"
+
 require "railjet"
 require "railjet/bus"
 
-require "wisper"
-require "wisper/sidekiq"
 
 Railjet::Bus.adapter = Wisper

--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -52,6 +52,14 @@ module Railjet
         define_listeners(event, &block)
       end
 
+      def sidekiq_options(options = {})
+        if options.present?
+          @sidekiq_options = options
+        else
+          @sidekiq_options
+        end
+      end
+
       private
 
       def define_listeners(event, &block)

--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -42,12 +42,7 @@ module Railjet
   class Listener
     include Railjet::Util::UseCaseHelper
 
-    def self.inherited(klass)
-      # If klass already respond to ::sidekiq_options_hash we're in a Child class and we don't want to create it again
-      unless klass.respond_to?(:sidekiq_options_hash)
-        klass.class_attribute :sidekiq_options_hash, default: Sidekiq.default_worker_options
-      end
-    end
+    class_attribute :sidekiq_options_hash, default: ::Sidekiq.default_worker_options
 
     class << self
       def subscriptions

--- a/lib/railjet/bus.rb
+++ b/lib/railjet/bus.rb
@@ -42,6 +42,13 @@ module Railjet
   class Listener
     include Railjet::Util::UseCaseHelper
 
+    def self.inherited(klass)
+      # If klass already respond to ::sidekiq_options_hash we're in a Child class and we don't want to create it again
+      unless klass.respond_to?(:sidekiq_options_hash)
+        klass.class_attribute :sidekiq_options_hash, default: Sidekiq.default_worker_options
+      end
+    end
+
     class << self
       def subscriptions
         @subscriptions ||= []
@@ -54,9 +61,9 @@ module Railjet
 
       def sidekiq_options(options = {})
         if options.present?
-          @sidekiq_options = options
+          self.sidekiq_options_hash = self.sidekiq_options_hash.merge(options.stringify_keys)
         else
-          @sidekiq_options
+          self.sidekiq_options_hash
         end
       end
 

--- a/spec/railjet/listener_spec.rb
+++ b/spec/railjet/listener_spec.rb
@@ -14,9 +14,8 @@ describe Railjet::Listener do
     end
   end
 
-  class DummyListenerChild < DummyListener
-    sidekiq_options retry: false
-  end
+  DummyListenerChild     = Class.new(DummyListener) { sidekiq_options retry: false }
+  DummyListenerNoOptions = Class.new(Railjet::Listener)
 
   subject(:listener) { DummyListener }
 
@@ -30,6 +29,10 @@ describe Railjet::Listener do
 
   it "allows to override sidekiq options in a child class" do
     expect(DummyListenerChild.sidekiq_options).to eq({ "queue" => :listener, "retry" => false })
+  end
+
+  it "uses sidekiq default options if nothing is specified" do
+    expect(DummyListenerNoOptions.sidekiq_options).to eq({ "queue" => "default", "retry" => true })
   end
 
   describe "calling through class method" do

--- a/spec/railjet/listener_spec.rb
+++ b/spec/railjet/listener_spec.rb
@@ -3,6 +3,8 @@ require "railjet/bus"
 
 describe Railjet::Listener do
   class DummyListener < Railjet::Listener
+    sidekiq_options queue: :listener
+
     listen_to :dummy_event do
       "Dummy event run"
     end
@@ -16,6 +18,10 @@ describe Railjet::Listener do
 
   it "registers subscriptions" do
     expect(listener.subscriptions).to eq %i[dummy_event dummy_event_with_arg]
+  end
+
+  it "has sidekiq options" do
+    expect(listener.sidekiq_options).to eq({ queue: :listener })
   end
 
   describe "calling through class method" do


### PR DESCRIPTION
`wisper-sidekiq` now allows to define sidekiq options, but it's done in a way that is different from how we do it in Sidekiq.

This PR adds `::sidekiq_options` class method to mimic Sidekiq API

```ruby
module Worksheet
  class TeamAssignmentListener < Listener
    sidekiq_options queue: :listeners
  end
end
```